### PR TITLE
Potential fix for code scanning alert no. 15: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/lib/base/freesatv2.cpp
+++ b/lib/base/freesatv2.cpp
@@ -237,7 +237,7 @@ std::string freesatHuffmanDecoder::decode(const unsigned char *src, size_t size)
 				while ( currentEntry != NULL )
 				{
 					unsigned mask = 0, maskbit = 0x80000000;
-					short kk;
+					uint16_t kk;
 					for ( kk = 0; kk < currentEntry->bits; kk++)
 					{
 						mask |= maskbit;


### PR DESCRIPTION
Potential fix for [https://github.com/jbleyel/enigma2/security/code-scanning/15](https://github.com/jbleyel/enigma2/security/code-scanning/15)

To fix the issue, the type of `kk` should be changed from `short` to `uint16_t`, which matches the type of `currentEntry->bits`. This ensures that the comparison `kk < currentEntry->bits` is performed between values of the same type, eliminating the risk of overflow or type mismatch. The change should be made in the declaration of `kk` on line 240.

No additional methods, imports, or definitions are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
