### PR TITLE
Potential fix for code scanning alert no. 16: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/lib/dvb/atsc.cpp
+++ b/lib/dvb/atsc.cpp
@@ -435,7 +435,7 @@ const MasterGuideTableList *MasterGuideTableSection::getTables(void) const
 
 ATSCEvent::ATSCEvent(const uint8_t * const buffer)
 {
-	uint16_t i;
+	uint32_t i;
 	eventId = UINT16(&buffer[0]) & 0x3fff;
 	startTime = UINT32(&buffer[2]);
 	ETMLocation = (buffer[6] >> 4) & 0x3;


### PR DESCRIPTION
Potential fix for [https://github.com/jbleyel/enigma2/security/code-scanning/16](https://github.com/jbleyel/enigma2/security/code-scanning/16)

To fix the issue, the type of the loop variable `i` should be widened to ensure it can safely compare against the expression `12 + titleLength + descriptorsLoopLength`. The best approach is to change the type of `i` from `uint16_t` to `uint32_t`, which is wide enough to handle the comparison without overflow. This change should be made at the declaration of `i` on line 438.

No additional imports or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
