### PR TITLE
Potential fix for code scanning alert no. 17: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/lib/dvb/atsc.cpp
+++ b/lib/dvb/atsc.cpp
@@ -378,7 +378,7 @@ MasterGuideTable::MasterGuideTable(const uint8_t * const buffer)
 	numberBytes = UINT32(&buffer[5]);
 	descriptorsLoopLength = UINT16(&buffer[9]) & 0xfff;
 
-	for (uint16_t i = 11; i < descriptorsLoopLength + 11; i += buffer[i + 1] + 2)
+	for (int i = 11; i < descriptorsLoopLength + 11; i += buffer[i + 1] + 2)
 	{
 		descriptor(&buffer[i], SCOPE_SI);
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/jbleyel/enigma2/security/code-scanning/17](https://github.com/jbleyel/enigma2/security/code-scanning/17)

To fix the issue, the type of `i` should be widened to match the type of the expression `descriptorsLoopLength + 11`. Since the addition promotes the type to `int`, changing `i` to `int` ensures that the comparison is performed between values of the same type, avoiding unexpected behavior due to type mismatch. This change will not affect the functionality of the loop but will make it safer and more robust.

The changes required are:
1. Update the declaration of `i` from `uint16_t` to `int`.
2. Ensure that the loop condition and increment logic remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
