### PR TITLE
Potential fix for code scanning alert no. 38: Redundant null check due to previous dereference

### DIFF
--- a/include/nanosvg.h
+++ b/include/nanosvg.h
@@ -296,6 +296,7 @@ static void nsvg__parseElement(char* s,
 		char quote;
 
 		// Skip white space before the attrib name
+		if (!s || !*s) break; // Check for null or end of string early
 		while (*s && nsvg__isspace(*s)) s++;
 		if (!*s) break;
 		if (*s == '/') {
@@ -317,7 +318,7 @@ static void nsvg__parseElement(char* s,
 		if (*s) { *s++ = '\0'; }
 
 		// Store only well formed attributes
-		if (nameAttrib && value) {
+		if (value) { // `nameAttrib` is guaranteed to be non-null here
 			attr[nattr++] = nameAttrib;
 			attr[nattr++] = value;
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/jbleyel/enigma2/security/code-scanning/38](https://github.com/jbleyel/enigma2/security/code-scanning/38)

To fix the issue, we need to ensure that the null check for `nameAttrib` (and indirectly `s`) is performed before any dereference of `s`. This can be achieved by moving the null check for `s` to the beginning of the loop, before any operations that dereference it. If `s` is null, the loop should terminate early to prevent undefined behavior. Additionally, the redundant null check for `nameAttrib` on line 320 can be safely removed since it will no longer be necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
